### PR TITLE
#38 Add stricter eslint rules

### DIFF
--- a/vue-thacer/.eslintrc.cjs
+++ b/vue-thacer/.eslintrc.cjs
@@ -4,10 +4,30 @@ require('@rushstack/eslint-patch/modern-module-resolution')
 module.exports = {
   root: true,
   extends: [
-    'plugin:vue/vue3-essential',
+    'plugin:vue/vue3-recommended',
     'eslint:recommended',
     '@vue/eslint-config-prettier/skip-formatting'
   ],
+  rules: {
+    // Reverse default :
+    'vue/attribute-hyphenation': ['error', 'never'],
+    // Already in "recommended" or "strongly recommended", but added here to raise error instead of warning :
+    'vue/attributes-order': ['error'],
+    'vue/component-tags-order': [
+      'error',
+      { order: ['template', 'script', 'style'] }],
+    'vue/order-in-components': ['error'],
+    'vue/v-bind-style': ['error'],
+    'vue/v-on-style': ['error'],
+    'vue/require-default-prop': ['error'],
+    'vue/component-definition-name-casing': ['error'],
+    // Extra vue rules ("uncategorized", or "extension rules") :
+    'vue/no-static-inline-styles': ['error'],
+    'vue/component-options-name-casing': ['error'],
+    'vue/component-name-in-template-casing': ['error'],
+    // general eslint (and not vue specific) rules :
+    curly: 'error'
+  },
   parserOptions: {
     ecmaVersion: 'latest'
   }


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/38`

**Description** :    
This PR uses the `recommended` set of vue eslint (instead of default `essentials`)
It also passes some rules in "error", and add some other rules.
It add one general / non-vue rule (`curly`)
