### PR TITLE
#35 Click on header link to home

### DIFF
--- a/vue-thacer/src/components/TheHeader.vue
+++ b/vue-thacer/src/components/TheHeader.vue
@@ -36,10 +36,10 @@
 
     <div class="navbar navbar-dark bg-dark shadow-sm my-0">
       <div class="container-fluid">
-        <a href="#" class="navbar-brand d-flex align-items-center py-0">
+        <router-link to="/" href="#" class="navbar-brand d-flex align-items-center py-0">
           <img src="@/assets/images/ThaCER.svg" class="img-fluid" alt="Responsive image" />
           <strong>THACER</strong>
-        </a>
+        </router-link>
 
         <!-- Bootstrap toggle button -->
         <button


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/35`

**Description** :    
Add the router-link attributes in the header, so that clicking on the header bring to the home page (map page)
