### PR TITLE
#76 Add sourcemap basically for sentry

### DIFF
--- a/vue-thacer/vite.config.js
+++ b/vue-thacer/vite.config.js
@@ -6,6 +6,9 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
   let config = {
+    build: {
+      sourcemap: true
+    },
     plugins: [vue()],
     resolve: {
       alias: {


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/76`

**Description** :    
Just generate the sourcemap for the production build.
This will allow to see the source in sentry. I think it's ok to have the sourcemap online, since the project is open source
Sentry ask to use the sentryVitePlugin, but let's just try like that, it may just work https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/#uploading-source-maps-to-sentry
