### PR TITLE
#41 implement multicriterium search

### DIFF
--- a/vue-thacer/src/assets/js/key-mapping.js
+++ b/vue-thacer/src/assets/js/key-mapping.js
@@ -1,5 +1,6 @@
-// This variable allows to map, for each key present in the data, the corresponding
-// keys that the user can use to search.
+// This variable will allow to map, for each key present in the geojson,
+// a list of the corresponding keys that the user may use when searching.
+// (The "user key" arrays (-> the property values) must be in lower cases)
 export const keyMapping = {
   ID: ['id'],
   Pi: ['pi'],
@@ -21,8 +22,8 @@ export const keyMapping = {
   geometry: ['geometry', 'geometrie', 'géometrie']
 }
 
-// Since keyMapping is human friendly but not developer friendly, we inverse it here.
-// this function return this kind of result :
+// Since the keyMapping variable is human friendly but not developer friendly, we inverse it here.
+// The function return this kind of result :
 // { inventaire: 'Inv_Fouille', inventory: 'Inv_Fouille', invfouille: 'Inv_Fouille',
 //  'inv-fouille': 'Inv_Fouille', inv_fouille: 'Inv_Fouille', archimage: 'Archimage',
 //   ... }
@@ -38,9 +39,9 @@ export const getInverseKeyMapping = () => {
   return inverseKeyMapping
 }
 
-// From a key that the user want to search in, we return the corresponding
-// "real" key used in the data. If not found, it will return undefined.
+// From a key that the user asked to search in, we return the corresponding
+// "real" key used in the geojson. If not found, it will return undefined.
+// (searchItemKey is expected to be lower case)
 export function mapToRealKeyName(searchItemKey) {
-  // debugger
   return getInverseKeyMapping()[searchItemKey]
 }

--- a/vue-thacer/src/assets/js/key-mapping.js
+++ b/vue-thacer/src/assets/js/key-mapping.js
@@ -1,0 +1,46 @@
+// This variable allows to map, for each key present in the data, the corresponding
+// keys that the user can use to search.
+export const keyMapping = {
+  ID: ['id'],
+  Pi: ['pi'],
+  Inv_Fouille: ['inventaire', 'inventory', 'invfouille', 'inv-fouille', 'inv_fouille'],
+  Archimage: ['archimage'],
+  Num_Analyse: ['num_analyse', 'num-analyse', 'numanalyse'],
+  secteur_ID: ['secteur_id', 'secteur-id', 'secteurid'],
+  annee: ['annee', 'année', 'year'],
+  Materiel: ['materiel', 'material'],
+  Famille: ['famille', 'family'],
+  Catégorie: ['catégorie', 'categorie', 'category'],
+  Type: ['type'],
+  Identification: ['identification'],
+  Description: ['description'],
+  Biblio: ['biblio', 'bibliography', 'bibliographie'],
+  Période: ['période', 'periode', 'period'],
+  x: ['x'],
+  y: ['y'],
+  geometry: ['geometry', 'geometrie', 'géometrie']
+}
+
+// Since keyMapping is human friendly but not developer friendly, we inverse it here.
+// this function return this kind of result :
+// { inventaire: 'Inv_Fouille', inventory: 'Inv_Fouille', invfouille: 'Inv_Fouille',
+//  'inv-fouille': 'Inv_Fouille', inv_fouille: 'Inv_Fouille', archimage: 'Archimage',
+//   ... }
+export const getInverseKeyMapping = () => {
+  let inverseKeyMapping = {}
+  for (const realDataKey in keyMapping) {
+    const acceptedKeysArray = keyMapping[realDataKey]
+    for (const acceptedKey of acceptedKeysArray) {
+      inverseKeyMapping[acceptedKey] = realDataKey
+    }
+  }
+
+  return inverseKeyMapping
+}
+
+// From a key that the user want to search in, we return the corresponding
+// "real" key used in the data. If not found, it will return undefined.
+export function mapToRealKeyName(searchItemKey) {
+  // debugger
+  return getInverseKeyMapping()[searchItemKey]
+}

--- a/vue-thacer/src/assets/js/key-mapping.js
+++ b/vue-thacer/src/assets/js/key-mapping.js
@@ -18,8 +18,7 @@ export const keyMapping = {
   Biblio: ['biblio', 'bibliography', 'bibliographie'],
   Période: ['période', 'periode', 'period'],
   x: ['x'],
-  y: ['y'],
-  geometry: ['geometry', 'geometrie', 'géometrie']
+  y: ['y']
 }
 
 // Since the keyMapping variable is human friendly but not developer friendly, we inverse it here.

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -111,7 +111,7 @@ function isSearchItemSingleFound(searchItemSingle, ceramObject) {
 
     const isValueContainedInIdentification =
       Boolean(ceramObject['Identification']) &&
-      ceramObject['Identification'].toLowerCase().isearchItemSingleSplit
+      ceramObject['Identification'].toLowerCase().includes(searchItemValue)
 
     const isValueEqualsPi =
       Boolean(ceramObject['Pi']) && ceramObject['Pi'].toLowerCase() === searchItemValue

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -105,7 +105,7 @@ const doesCeramObjectPassesInputSearchString = (ceramObject, inputSearchString) 
 function isSearchItemSingleFound(searchItemSingle, ceramObject) {
   const searchItemSingleSplit = searchItemSingle.split(':')
 
-  // Search without key :
+  // Search without key will hit three fields: Identification, Pi, Description :
   if (searchItemSingleSplit.length === 1) {
     const searchItemValue = searchItemSingleSplit[0]
 

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -9,6 +9,7 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
       let inputSearchString = e.target.value.trim().toLowerCase()
       document.getElementById('nonloc').innerHTML = []
 
+      document.getElementById('loading-unlocalised').classList.remove('d-none')
       fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
         .then((r) => r.json())
         .then((json) => {
@@ -35,12 +36,15 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
               ]
             }
           })
+
+          document.getElementById('loading-unlocalised').classList.add('d-none')
         })
 
       markerClusterGroupCeram.clearLayers()
       map.removeLayer(markerClusterGroupCeram)
       featureLayerCeram.loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson') // je ne sais pourquoi j'avais mis ça là, déjà fait plus haut mais sinon map.addlayer ne marche pas
 
+      document.getElementById('loading-localised').classList.remove('d-none')
       featureLayerCeram
         .setFilter((e) => {
           // Adding current ceramObject only if localised and passing input search string :
@@ -54,7 +58,9 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
             setCeramLayer(layer)
             markerClusterGroupCeram.addLayer(layer)
           })
+          document.getElementById('loading-localised').classList.add('d-none')
         })
+
       map.addLayer(markerClusterGroupCeram)
     }
   })

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -82,8 +82,9 @@ const doesCeramObjectPassesInputSearchString = (ceramObject, inputSearchString) 
     return false
   }
 
-  // Trim :
+  // Trim and lower case :
   inputSearchString = inputSearchString.trim()
+  inputSearchString = inputSearchString.toLowerCase()
 
   // If empty search query :
   if (inputSearchString === '') {
@@ -100,6 +101,7 @@ const doesCeramObjectPassesInputSearchString = (ceramObject, inputSearchString) 
 }
 
 // this function is launched for each search item, to check if it passes with current ceramObject
+// (searchItemSingle is expected to be lower case)
 function isSearchItemSingleFound(searchItemSingle, ceramObject) {
   const searchItemSingleSplit = searchItemSingle.split(':')
 
@@ -111,7 +113,8 @@ function isSearchItemSingleFound(searchItemSingle, ceramObject) {
       Boolean(ceramObject['Identification']) &&
       ceramObject['Identification'].toLowerCase().isearchItemSingleSplit
 
-    const isValueEqualsPi = Boolean(ceramObject['Pi']) && ceramObject['Pi'] === searchItemValue
+    const isValueEqualsPi =
+      Boolean(ceramObject['Pi']) && ceramObject['Pi'].toLowerCase() === searchItemValue
 
     const isValueContainedInDescription =
       Boolean(ceramObject['Description']) &&
@@ -120,9 +123,10 @@ function isSearchItemSingleFound(searchItemSingle, ceramObject) {
     return isValueContainedInIdentification || isValueEqualsPi || isValueContainedInDescription
   }
   // Search with key :
-  // If more than 2 element, there was 2 or more colon, we just skip after the second colon
+  // (More than 2 elements would mean that there was 2 or more colons in the searchItemSingle.
+  // In this case we will just not consider everything after the second colon)
   else if (searchItemSingleSplit.length >= 2) {
-    const searchItemValue = searchItemSingleSplit[1].toLowerCase()
+    const searchItemValue = searchItemSingleSplit[1]
     let searchItemKey = searchItemSingleSplit[0]
     searchItemKey = mapToRealKeyName(searchItemKey)
 

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -1,30 +1,12 @@
 import { isObject } from '@/assets/js/utils.js'
 import { setCeramLayer } from '@/assets/js/thacer-map-create-layer'
-
-const doesCeramObjectPassesSearch = (ceramObject, searchString) => {
-  if (!isObject(ceramObject)) {
-    console.error(`Error in doesCeramObjectPassFilter, ceramObject is not an object :`, ceramObject)
-    return false
-  }
-
-  const isValueContainedInIdentification =
-    ceramObject['Identification'] &&
-    ceramObject['Identification'].toString().toLowerCase().includes(searchString)
-
-  const isValueEqualsPi = ceramObject['Pi'] && ceramObject['Pi'] === searchString
-
-  const isValueContainedInDescription =
-    ceramObject['Description'] &&
-    ceramObject['Description'].toString().toLowerCase().includes(searchString)
-
-  return isValueContainedInIdentification || isValueEqualsPi || isValueContainedInDescription
-}
+import { mapToRealKeyName } from '@/assets/js/key-mapping'
 
 export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram) {
   let filterInput = document.getElementById('filter-input')
   filterInput.addEventListener('keyup', function (e) {
     if (e.keyCode == 13) {
-      let value = e.target.value.trim().toLowerCase()
+      let inputSearchString = e.target.value.trim().toLowerCase()
       document.getElementById('nonloc').innerHTML = []
 
       fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
@@ -33,22 +15,24 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
           Object.keys(json.features).forEach((k) => {
             let obj = json.features[k]
 
-            if (obj.properties.x == 0) {
-              if (doesCeramObjectPassesSearch(obj.properties, value)) {
-                let label
-                if (obj.properties.Pi != null) {
-                  label = 'Π' + obj.properties.Pi
-                } else {
-                  label = obj.properties.Inv_Fouille
-                }
-                document.getElementById('nonloc').innerHTML += [
-                  '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
-                    obj.properties.ID +
-                    '&ANA=8888880&INV=88880">' +
-                    label +
-                    '</a>'
-                ]
+            // Adding current ceramObject only if unlocalised and passing input search string :
+            if (
+              obj.properties.x == 0 &&
+              doesCeramObjectPassesInputSearchString(obj.properties, inputSearchString)
+            ) {
+              let label
+              if (obj.properties.Pi != null) {
+                label = 'Π' + obj.properties.Pi
+              } else {
+                label = obj.properties.Inv_Fouille
               }
+              document.getElementById('nonloc').innerHTML += [
+                '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
+                  obj.properties.ID +
+                  '&ANA=8888880&INV=88880">' +
+                  label +
+                  '</a>'
+              ]
             }
           })
         })
@@ -58,7 +42,13 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
       featureLayerCeram.loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson') // je ne sais pourquoi j'avais mis ça là, déjà fait plus haut mais sinon map.addlayer ne marche pas
 
       featureLayerCeram
-        .setFilter((e) => doesCeramObjectPassesSearch(e?.properties, value))
+        .setFilter((e) => {
+          // Adding current ceramObject only if localised and passing input search string :
+          return (
+            e.properties.x != 0 &&
+            doesCeramObjectPassesInputSearchString(e?.properties, inputSearchString)
+          )
+        })
         .on('ready', function (e) {
           e.target.eachLayer(function (layer) {
             setCeramLayer(layer)
@@ -70,6 +60,76 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
   })
 }
 
+// This function will be launched for each ceramObject.
+// It returns true if ceramObject correspond with the input search string
+const doesCeramObjectPassesInputSearchString = (ceramObject, inputSearchString) => {
+  // Programmatic errors :
+  if (!isObject(ceramObject)) {
+    console.error(`Error in doesCeramObjectPassFilter, ceramObject is not an object :`, ceramObject)
+    return false
+  }
+  if (typeof inputSearchString !== 'string') {
+    console.error(
+      `Error in doesCeramObjectPassFilter, inputSearchString is not an string :`,
+      inputSearchString
+    )
+    return false
+  }
+
+  // Trim :
+  inputSearchString = inputSearchString.trim()
+
+  // If empty search query :
+  if (inputSearchString === '') {
+    return true
+  }
+
+  // All good until here, let's search :
+  let searchItemArray = inputSearchString.split(' ')
+  // For the user search input to "pass" for this ceramObject,
+  // each (every) single search item would have to return true
+  return searchItemArray.every((searchItemSingle) =>
+    isSearchItemSingleFound(searchItemSingle, ceramObject)
+  )
+}
+
+// this function is launched for each search item, to check if it passes with current ceramObject
+function isSearchItemSingleFound(searchItemSingle, ceramObject) {
+  const searchItemSingleSplit = searchItemSingle.split(':')
+
+  // Search without key :
+  if (searchItemSingleSplit.length === 1) {
+    const searchItemValue = searchItemSingleSplit[0]
+
+    const isValueContainedInIdentification =
+      Boolean(ceramObject['Identification']) &&
+      ceramObject['Identification'].toLowerCase().isearchItemSingleSplit
+
+    const isValueEqualsPi = Boolean(ceramObject['Pi']) && ceramObject['Pi'] === searchItemValue
+
+    const isValueContainedInDescription =
+      Boolean(ceramObject['Description']) &&
+      ceramObject['Description'].toLowerCase().includes(searchItemValue)
+
+    return isValueContainedInIdentification || isValueEqualsPi || isValueContainedInDescription
+  }
+  // Search with key :
+  // If more than 2 element, there was 2 or more colon, we just skip after the second colon
+  else if (searchItemSingleSplit.length >= 2) {
+    const searchItemValue = searchItemSingleSplit[1].toLowerCase()
+    let searchItemKey = searchItemSingleSplit[0]
+    searchItemKey = mapToRealKeyName(searchItemKey)
+
+    if (!ceramObject[searchItemKey]) {
+      return false
+    }
+
+    return ceramObject[searchItemKey].toLowerCase().includes(searchItemValue)
+  }
+
+  return true
+}
+
 export function searchCeramByClick(featureLayerCeram, markerClusterGroupCeram, map, layer) {
   map.removeLayer(markerClusterGroupCeram)
   markerClusterGroupCeram.clearLayers()
@@ -77,6 +137,7 @@ export function searchCeramByClick(featureLayerCeram, markerClusterGroupCeram, m
   featureLayerCeram.loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
   featureLayerCeram
     .setFilter(function (feature) {
+      // Searching / Filtering for "click search" takes place here :
       return feature.properties['secteur_ID'] == value
     })
     .on('ready', function (e) {

--- a/vue-thacer/src/components/TheMapSearch.vue
+++ b/vue-thacer/src/components/TheMapSearch.vue
@@ -6,6 +6,19 @@
       name="filter"
       placeholder="Recherche. Exemples : plat id:9130 invFouille:Indéterminé"
     />
+
+    <div id="loading-localised" class="d-none loading-text m-2 mt-3">
+      <div class="spinner-border spinner-border-sm" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      recherche d'éléments localisés en cours...
+    </div>
+    <div id="loading-unlocalised" class="d-none loading-text m-2">
+      <div class="spinner-border spinner-border-sm" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      recherche d'éléments non-localisés en cours...
+    </div>
   </div>
 </template>
 
@@ -18,6 +31,10 @@ export default {
 <style scoped>
 .filter-ctrl {
   width: 220px;
+}
+
+.loading-text {
+  font-size: 10px;
 }
 
 .filter-ctrl input[type='text'] {

--- a/vue-thacer/src/components/TheMapSearch.vue
+++ b/vue-thacer/src/components/TheMapSearch.vue
@@ -4,7 +4,7 @@
       id="filter-input"
       type="text"
       name="filter"
-      placeholder="ex. 2085, 2057, plat, cratère, amphore..."
+      placeholder="Recherche. Exemples : plat id:9130 invFouille:Indéterminé"
     />
   </div>
 </template>


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/41`

**Description** :    
This PR allow to search by precising the id. For instance :  `plat id:9130 invFouille:Indéterminé`
It allows multi search
It introduce a key mapping file where we can define all the authorised key for search (for instance, `invFouille`, `inv-fouILLE`, `Inv_Fouille` would search in the "real" `Inv_Fouille`
It also adds some basic spinner
For a few other things, see the single commit lists
