### PR TITLE
Fix Map vertical scrollbar

### DIFF
--- a/vue-thacer/src/components/TheMap.vue
+++ b/vue-thacer/src/components/TheMap.vue
@@ -1,32 +1,34 @@
 <template>
   <TheMapMainDisplay class="map-main-display"></TheMapMainDisplay>
   <TheMapSearch class="position-absolute map-search"></TheMapSearch>
-  <TheMapInsertUnlocalised class="map-insert-unlocalised"></TheMapInsertUnlocalised>
+  <TheMapInsertUnlocalised
+    class="map-insert-unlocalised"
+  ></TheMapInsertUnlocalised>
   <TheMapFooter class="map-footer"></TheMapFooter>
 </template>
 
 <script>
-import TheMapSearch from '@/components/TheMapSearch.vue'
-import TheMapInsertUnlocalised from '@/components/TheMapInsertUnlocalised.vue'
-import TheMapMainDisplay from '@/components/TheMapMainDisplay.vue'
-import TheMapFooter from '@/components/TheMapFooter.vue'
+import TheMapSearch from "@/components/TheMapSearch.vue";
+import TheMapInsertUnlocalised from "@/components/TheMapInsertUnlocalised.vue";
+import TheMapMainDisplay from "@/components/TheMapMainDisplay.vue";
+import TheMapFooter from "@/components/TheMapFooter.vue";
 
 export default {
-  name: 'TheMap',
+  name: "TheMap",
   components: {
     TheMapFooter,
     TheMapMainDisplay,
     TheMapInsertUnlocalised,
-    TheMapSearch
-  }
-}
+    TheMapSearch,
+  },
+};
 </script>
 
 <style scoped>
 .map-main-display {
   position: fixed;
   width: 100%;
-  height: 95%;
+  height: calc(100vh - 50.3px);
 }
 
 .map-search {

--- a/vue-thacer/src/components/TheMapFooter.vue
+++ b/vue-thacer/src/components/TheMapFooter.vue
@@ -1,15 +1,15 @@
 <template>
   <footer class="text-muted">
     <div class="container-fluid">
-      <p>&copy; ThaCER et contributeurs AC AT CW FB JJM JK JSG MFP MP</p>
+      <span>&copy; ThaCER et contributeurs AC AT CW FB JJM JK JSG MFP MP</span>
     </div>
   </footer>
 </template>
 
 <script>
 export default {
-  name: 'TheMapFooter'
-}
+  name: "TheMapFooter",
+};
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
#90 Adjust the height of the Map to match the viewport height and remove vertical scrollbar

**Description** :    
The problem is caused by a <p> in the footer, which adds blank space at the bottom. Replacing <p> with <span> solves the problem, and there is no need to hide overflow of the <html> since the map has its own overflow hidden.
The footer needs further fixing as it conflicts with the attribution line of the map tiles. The footer line can be removed completely or it can be added to the map attribution.
