### PR TITLE
Re-apply some of the reverted commits of #86 sentry

### DIFF
--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -1,4 +1,4 @@
-import { isObject } from '@/assets/js/utils.js'
+import { isObject, notifyProgrammaticError } from '@/assets/js/utils.js'
 import { setCeramLayer } from '@/assets/js/thacer-map-create-layer'
 import { mapToRealKeyName } from '@/assets/js/key-mapping'
 
@@ -71,13 +71,14 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
 const doesCeramObjectPassesInputSearchString = (ceramObject, inputSearchString) => {
   // Programmatic errors :
   if (!isObject(ceramObject)) {
-    console.error(`Error in doesCeramObjectPassFilter, ceramObject is not an object :`, ceramObject)
+    notifyProgrammaticError(
+      `Error in doesCeramObjectPassFilter, ceramObject is not an object : ${ceramObject}`
+    )
     return false
   }
   if (typeof inputSearchString !== 'string') {
-    console.error(
-      `Error in doesCeramObjectPassFilter, inputSearchString is not an string :`,
-      inputSearchString
+    notifyProgrammaticError(
+      `Error in doesCeramObjectPassFilter, inputSearchString is not an string :  ${ceramObject}`
     )
     return false
   }

--- a/vue-thacer/src/assets/js/utils.js
+++ b/vue-thacer/src/assets/js/utils.js
@@ -1,3 +1,10 @@
+import * as Sentry from '@sentry/vue'
+
 export const isObject = (o) => {
   return typeof o === 'object' && !Array.isArray(o) && o !== null
+}
+
+export const notifyProgrammaticError = (message) => {
+  console.error(message)
+  Sentry.captureMessage(message)
 }

--- a/vue-thacer/src/components/TheCeramic.vue
+++ b/vue-thacer/src/components/TheCeramic.vue
@@ -58,7 +58,7 @@
 import TheCeramicText from '@/components/TheCeramicText.vue'
 import TheCeramicChart from '@/components/TheCeramicChart.vue'
 import TheCeramicImages from '@/components/TheCeramicImages.vue'
-import { isObject } from '@/assets/js/utils.js'
+import { isObject, notifyProgrammaticError } from '@/assets/js/utils.js'
 import TheCeramicArchimage from '@/components/TheCeramicArchimage.vue'
 
 export default {
@@ -88,7 +88,9 @@ export default {
           this.imageUrlArrayList = imageUrlArrayList
           this.loadingStatusImagesUrls = 'loaded'
         } else {
-          console.error(imageUrlArrayList)
+          notifyProgrammaticError(
+            `Error, imageUrlArrayList is not an object : ${imageUrlArrayList}`
+          )
           this.loadingStatusImagesUrls = 'error'
         }
       })

--- a/vue-thacer/src/main.js
+++ b/vue-thacer/src/main.js
@@ -15,7 +15,9 @@ Sentry.init({
   integrations: [
     new BrowserTracing({
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-      tracePropagationTargets: ['localhost', '127.0.0.1', 'thacer.archaiodata.com', /^\//]
+      tracePropagationTargets: ['thacer.archaiodata.com', /^\//]
+      // Uncomment for using sentry in dev :
+      // tracePropagationTargets: ['localhost', '127.0.0.1', 'thacer.archaiodata.com', /^\//]
     })
   ],
   // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/96`

**Description** :    
We want to have some of the functionnalities of https://github.com/archaiodata/thacer/issues/86, but not the buggy sentry vite plugin. (we also didn't re-add the Sentry test component)
So this PR finally : 
- Create the notifyProgrammaticError function
- Disable sentry for dev environment
