### PR TITLE
#103 refactor map layers to use leaflet instead of mapbox

### DIFF
--- a/vue-thacer/index.html
+++ b/vue-thacer/index.html
@@ -1,50 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-38076700-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
-      gtag('config', 'UA-38076700-2')
-    </script>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <script src="https://api.tiles.mapbox.com/mapbox.js/v2.4.0/mapbox.js"></script>
-    <link href="https://api.tiles.mapbox.com/mapbox.js/v2.4.0/mapbox.css" rel="stylesheet" />
-    <script src="//api.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js"></script>
-    <link
-      href="//api.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css"
-      rel="stylesheet"
-    />
-    <link
-      href="//api.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css"
-      rel="stylesheet"
-    />
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-38076700-2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+      dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', 'UA-38076700-2')
+  </script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
+    integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI=" crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
+    integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM=" crossorigin=""></script>
 
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD"
-      crossorigin="anonymous"
-    />
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
-      crossorigin="anonymous"
-    ></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+  <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+    crossorigin="anonymous"></script>
 
-    <title>Thacer</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
-  </body>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+
+  <title>Thacer</title>
+</head>
+
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
 </html>

--- a/vue-thacer/index.html
+++ b/vue-thacer/index.html
@@ -14,27 +14,6 @@
       gtag('js', new Date())
       gtag('config', 'UA-38076700-2')
     </script>
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
-      integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI="
-      crossorigin=""
-    />
-    <script
-      src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
-      integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM="
-      crossorigin=""
-    ></script>
-
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"
-    />
-    <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"

--- a/vue-thacer/index.html
+++ b/vue-thacer/index.html
@@ -1,43 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-38076700-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-38076700-2')
+    </script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
+      integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI="
+      crossorigin=""
+    />
+    <script
+      src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
+      integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM="
+      crossorigin=""
+    ></script>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-38076700-2"></script>
-  <script>
-    window.dataLayer = window.dataLayer || []
-    function gtag() {
-      dataLayer.push(arguments)
-    }
-    gtag('js', new Date())
-    gtag('config', 'UA-38076700-2')
-  </script>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
-    integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI=" crossorigin="" />
-  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
-    integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM=" crossorigin=""></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"
+    />
+    <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 
-  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
-  <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD"
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+      crossorigin="anonymous"
+    ></script>
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous" />
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
-    crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+    <title>Thacer</title>
+  </head>
 
-  <title>Thacer</title>
-</head>
-
-<body>
-  <div id="app"></div>
-  <script type="module" src="/src/main.js"></script>
-</body>
-
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
 </html>

--- a/vue-thacer/package-lock.json
+++ b/vue-thacer/package-lock.json
@@ -11,6 +11,8 @@
         "@sentry/tracing": "^7.43.0",
         "@sentry/vue": "^7.43.0",
         "bootstrap-icons": "^1.10.3",
+        "leaflet": "^1.9.3",
+        "leaflet.markercluster": "^1.5.3",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6"
       },
@@ -1513,6 +1515,19 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3261,6 +3276,17 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+    },
+    "leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "requires": {}
     },
     "levn": {
       "version": "0.4.1",

--- a/vue-thacer/package.json
+++ b/vue-thacer/package.json
@@ -13,6 +13,8 @@
     "@sentry/tracing": "^7.43.0",
     "@sentry/vue": "^7.43.0",
     "bootstrap-icons": "^1.10.3",
+    "leaflet": "^1.9.3",
+    "leaflet.markercluster": "^1.5.3",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6"
   },

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -135,7 +135,7 @@ export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
     })
 
   search.setupSearchCeramByText(markerClusterGroupCeram, map)
-  designMarkersCeram(featureLayerCeram)
+  designMarkersCeram(markerClusterGroupCeram)
 
   return featureLayerCeram
 }
@@ -149,8 +149,8 @@ export function createMarkerClusterGroupCeram() {
   })
 }
 
-function designMarkersCeram(featureLayerCeram) {
-  featureLayerCeram.on('layeradd', function (e) {
+function designMarkersCeram(layer) {
+  layer.on('layeradd', function (e) {
     let identifier
     let marker = e.layer,
       feature = marker.feature

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -258,23 +258,27 @@ export function createTileLayerOrthophotoAgora() {
   })
 }
 
-/*export function createFeatureLayerEchantillonsGeol() {
-  return L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/echantillonsgeol.geojson')
-    .on('layeradd', function (e) {
-      let marker = e.layer,
-        feature = marker.feature
-      marker.setIcon(
-        L.divIcon({
-          html: feature.properties.RecNum,
-          className: 'marker echantillons-geol-marker',
-          iconSize: 'null'
-        })
-      )
-    })
+export function createFeatureLayerEchantillonsGeol() {
+  let echantillons = L.featureGroup();
+  fetch(import.meta.env.VITE_API_URL + 'geojson/echantillonsgeol.geojson')
+    .then(response => response.json())
+    .then(data => {
+      let layer = L.geoJSON(data, {
+        pointToLayer: function (feature, latlng) {
+          return L.marker(latlng, {
+            icon: L.divIcon({
+              html: feature.properties.RecNum,
+              className: 'marker echantillons-geol-marker',
+              iconSize: null
+            })
+          });
+        }
+      });
+      echantillons.addLayer(layer);
+    });
+  return echantillons;
 }
-*/
+
 /*export function createFeatureLayerADelt(map) {
   let ADelt = L.mapbox
     .featureLayer()

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -63,55 +63,61 @@ export function setCeramLayer(ceramLayer) {
   )
 }
 
-//export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) {
-/* global L */
-/*  return L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/secteurs.geojson')
-    .on('ready', function (e) {
-      // function select ceram according to the secteurs ID on the clicked secteur feature
-      e.target.eachLayer(function (layer) {
-        layer.eachLayer(function (e) {
-          let string = ''
-          let biblio = ''
-          if (
-            !(
-              // GTh means "Guide de Thasos"
-              (
-                (layer.feature.properties.GTh == '') |
-                (layer.feature.properties.GTh == 'null') |
-                (layer.feature.properties.GTh == undefined)
-              )
+export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) {
+  // create a new leaflet GeoJSON layer
+  const layer = L.geoJSON();
+
+  // fetch the data from the API URL using the fetch method
+  fetch(import.meta.env.VITE_API_URL + 'geojson/secteurs.geojson')
+    .then(response => response.json()) // parse the response as JSON
+    .then(data => {
+      // add the GeoJSON data to the leaflet layer
+      layer.addData(data);
+
+      // set up the popup and click events for each layer
+      layer.eachLayer(function (e) {
+        let string = ''
+        let biblio = ''
+        if (
+          !(
+            // GTh means "Guide de Thasos"
+            (
+              (e.feature.properties.GTh == '') |
+              (e.feature.properties.GTh == 'null') |
+              (e.feature.properties.GTh == undefined)
             )
-          ) {
-            string = ' GTh' + layer.feature.properties.GTh
-          }
-          if (
-            !(
-              (layer.feature.properties.Référenc == '') |
-              (layer.feature.properties.Référenc == 'null') |
-              (layer.feature.properties.Référenc == undefined)
-            )
-          ) {
-            biblio = layer.feature.properties.Référenc
-          }
-          e.bindPopup(layer.feature.properties.Titre + string + '<br>' + biblio, {
-            maxWidth: 300,
-            minWidth: 10,
-            maxHeight: 250,
-            autoPan: true,
-            closeButton: false,
-            autoPanPadding: [0, 0]
-          })
-          // search ceram on click
-          e.on('click', function () {
-            search.searchCeramByClick(ceram, markerClusterGroupCeram, map, layer)
-          })
+          )
+        ) {
+          string = ' GTh' + e.feature.properties.GTh
+        }
+        if (
+          !(
+            (e.feature.properties.Référenc == '') |
+            (e.feature.properties.Référenc == 'null') |
+            (e.feature.properties.Référenc == undefined)
+          )
+        ) {
+          biblio = e.feature.properties.Référenc
+        }
+        e.bindPopup(e.feature.properties.Titre + string + '<br>' + biblio, {
+          maxWidth: 300,
+          minWidth: 10,
+          maxHeight: 250,
+          autoPan: true,
+          closeButton: false,
+          autoPanPadding: [0, 0]
         })
-      })
-    })
+        // search ceram on click
+        e.on('click', function () {
+          search.searchCeramByClick(ceram, markerClusterGroupCeram, map, e)
+        })
+      });
+    });
+
+  // return the leaflet layer
+  return layer;
 }
-*/
+
 export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
   fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
     .then(response => response.json())

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -160,18 +160,27 @@ function designMarkersCeram(featureLayerCeram) {
   })
 }
 
-/*export function createFeatureLayerVestiges() {
-  let vestiges = L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/vestiges.geojson')
+export function createFeatureLayerVestiges() {
+  let vestiges = L.featureGroup();
+
+  // Load GeoJSON data from URL
+  fetch(import.meta.env.VITE_API_URL + 'geojson/vestiges.geojson')
+    .then(res => res.json())
+    .then(data => {
+      // Create a Leaflet GeoJSON layer from the data
+      let layer = L.geoJSON(data);
+
+      // Add the layer to the feature group
+      vestiges.addLayer(layer);
+    });
 
   vestiges.getAttribution = function () {
-    return 'Plan des vestiges antique : MWK TK EfA'
-  }
+    return 'Plan des vestiges antique : MWK TK EfA';
+  };
 
-  return vestiges
+  return vestiges;
 }
-*/
+
 export function createImageOverlayKhalil(map) {
   let KhalilimageBounds = [
     [40.768370395, 24.699482062],

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -1,4 +1,5 @@
 import * as search from '@/assets/js/thacer-map-setup-search'
+import L from 'leaflet'
 
 function createCeramUrl(ceramLayer, identifier) {
   return (

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -119,10 +119,13 @@ export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) 
 }
 
 export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
+  // create a new leaflet GeoJSON layer
+  let featureLayerCeram = L.geoJSON();
+
   fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
     .then(response => response.json())
     .then(data => {
-      let featureLayerCeram = L.geoJSON(data, {
+      featureLayerCeram = L.geoJSON(data, {
         onEachFeature: function (feature, layer) {
           setCeramLayer(layer);
           markerClusterGroupCeram.addLayer(layer);
@@ -133,9 +136,8 @@ export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
         search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram);
         designMarkersCeram(featureLayerCeram);
       });
-
-      return featureLayerCeram;
     });
+  return featureLayerCeram;
 }
 
 export function createMarkerClusterGroupCeram() {

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -196,26 +196,29 @@ export function createImageOverlayKhalil(map) {
   return L.imageOverlay(import.meta.env.VITE_API_URL + 'IMAGES/1685.png', KhalilimageBounds)
 }
 
-/*export function createFeatureLayerChronique(markersChronique) {
-  L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/chronique.geojson')
-    .on('layeradd', function (e) {
-      e.target.eachLayer(function (layer) {
-        layer.on('click', function () {
-          window.open(
-            'https://chronique.efa.gr/?kroute=report&id=' + layer.feature.properties.ID,
-            '_blank'
-          )
-        })
-        markersChronique.addLayer(layer)
+export function createFeatureLayerChronique(markersChronique) {
+  fetch(import.meta.env.VITE_API_URL + 'geojson/chronique.geojson')
+    .then((response) => response.json())
+    .then((data) => {
+      L.geoJSON(data, {
+        onEachFeature: function (feature, layer) {
+          layer.on('click', function () {
+            window.open(
+              'https://chronique.efa.gr/?kroute=report&id=' + feature.properties.ID,
+              '_blank'
+            )
+          })
+          markersChronique.addLayer(layer)
+        },
+        pointToLayer: function (feature, latlng) {
+          return L.marker(latlng, {
+            icon: L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' }),
+          })
+        },
       })
-
-      let marker = e.layer
-      marker.setIcon(L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' }))
     })
 }
-*/
+
 export function createMarkerClusterGroupChronique() {
   return new L.MarkerClusterGroup({
     iconCreateFunction: function (cluster) {

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -319,11 +319,11 @@ export function createFeatureLayerADelt(map) {
     let cur_zoom = map.getZoom()
     if (cur_zoom <= 13) {
       ADelt.eachLayer(function (layer) {
-        layer.getElement().style.visibility = 'hidden'
+        map.removeLayer(layer)
       })
     } else if (cur_zoom > 13) {
       ADelt.eachLayer(function (layer) {
-        layer.getElement().style.visibility = 'visible'
+        map.addLayer(layer)
       })
     }
   }
@@ -331,36 +331,33 @@ export function createFeatureLayerADelt(map) {
   return ADelt
 }
 
-/*export function createFeatureLayerSites() {
-  return L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/sites.geojson')
-    .on('layeradd', function (e) {
-      if (e.layer.feature.properties.type == 'Atelier') {
-        e.layer.setIcon(
-          L.icon({
-            iconUrl: 'AmpTha.svg',
-            iconSize: [20, 50]
-          })
-        )
-      } else {
-        e.layer.setIcon(
-          L.icon({
-            iconUrl: 'https://upload.wikimedia.org/wikipedia/commons/8/84/Maki-castle-15.svg',
-            iconSize: [15, 35]
-          })
-        )
-      }
+export function createFeatureLayerSites() {
+  let sites = L.featureGroup();
 
-      e.target.eachLayer(function (layer) {
-        layer.bindPopup(layer.feature.properties.Nom + ': ' + layer.feature.properties.desc, {
-          maxWidth: 350,
-          maxHeight: 550,
-          autoPan: true,
-          closeButton: false,
-          autoPanPadding: [5, 5]
-        })
-      })
-    })
+  fetch(import.meta.env.VITE_API_URL + 'geojson/sites.geojson')
+    .then(response => response.json())
+    .then(data => {
+      L.geoJSON(data, {
+        pointToLayer: function (feature, latlng) {
+          let iconUrl = feature.properties.type === 'Atelier' ? 'AmpTha.svg' : 'https://upload.wikimedia.org/wikipedia/commons/8/84/Maki-castle-15.svg';
+          return L.marker(latlng, {
+            icon: L.icon({
+              iconUrl: iconUrl,
+              iconSize: feature.properties.type === 'Atelier' ? [20, 50] : [15, 35]
+            })
+          })
+        },
+        onEachFeature: function (feature, layer) {
+          layer.bindPopup(feature.properties.Nom + ': ' + feature.properties.desc, {
+            maxWidth: 350,
+            maxHeight: 550,
+            autoPan: true,
+            closeButton: false,
+            autoPanPadding: [5, 5]
+          });
+        }
+      }).addTo(sites);
+    });
+
+  return sites;
 }
-*/

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -63,9 +63,9 @@ export function setCeramLayer(ceramLayer) {
   )
 }
 
-export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) {
-  /* global L */
-  return L.mapbox
+//export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) {
+/* global L */
+/*  return L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/secteurs.geojson')
     .on('ready', function (e) {
@@ -111,8 +111,8 @@ export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) 
       })
     })
 }
-
-export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
+*/
+/*export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
   let featureLayerCeram = L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
@@ -130,7 +130,7 @@ export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
 
   return featureLayerCeram
 }
-
+*/
 export function createMarkerClusterGroupCeram() {
   return new L.MarkerClusterGroup({
     spiderfyOnMaxZoom: true,
@@ -160,7 +160,7 @@ function designMarkersCeram(featureLayerCeram) {
   })
 }
 
-export function createFeatureLayerVestiges() {
+/*export function createFeatureLayerVestiges() {
   let vestiges = L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/vestiges.geojson')
@@ -171,7 +171,7 @@ export function createFeatureLayerVestiges() {
 
   return vestiges
 }
-
+*/
 export function createImageOverlayKhalil(map) {
   let KhalilimageBounds = [
     [40.768370395, 24.699482062],
@@ -187,7 +187,7 @@ export function createImageOverlayKhalil(map) {
   return L.imageOverlay(import.meta.env.VITE_API_URL + 'IMAGES/1685.png', KhalilimageBounds)
 }
 
-export function createFeatureLayerChronique(markersChronique) {
+/*export function createFeatureLayerChronique(markersChronique) {
   L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/chronique.geojson')
@@ -206,7 +206,7 @@ export function createFeatureLayerChronique(markersChronique) {
       marker.setIcon(L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' }))
     })
 }
-
+*/
 export function createMarkerClusterGroupChronique() {
   return new L.MarkerClusterGroup({
     iconCreateFunction: function (cluster) {
@@ -246,7 +246,7 @@ export function createTileLayerOrthophotoAgora() {
   })
 }
 
-export function createFeatureLayerEchantillonsGeol() {
+/*export function createFeatureLayerEchantillonsGeol() {
   return L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/echantillonsgeol.geojson')
@@ -262,8 +262,8 @@ export function createFeatureLayerEchantillonsGeol() {
       )
     })
 }
-
-export function createFeatureLayerADelt(map) {
+*/
+/*export function createFeatureLayerADelt(map) {
   let ADelt = L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/ADelt51.geojson')
@@ -306,8 +306,8 @@ export function createFeatureLayerADelt(map) {
 
   return ADelt
 }
-
-export function createFeatureLayerSites() {
+*/
+/*export function createFeatureLayerSites() {
   return L.mapbox
     .featureLayer()
     .loadURL(import.meta.env.VITE_API_URL + 'geojson/sites.geojson')
@@ -339,3 +339,4 @@ export function createFeatureLayerSites() {
       })
     })
 }
+*/

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -280,50 +280,57 @@ export function createFeatureLayerEchantillonsGeol() {
   return echantillons;
 }
 
-/*export function createFeatureLayerADelt(map) {
-  let ADelt = L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/ADelt51.geojson')
-    .on('ready', function (e) {
-      e.target.eachLayer(function (layer) {
-        layer.bindPopup('ADelt 51 : "' + layer.feature.properties.Texte + '"<br>', {
-          maxWidth: 350,
-          maxHeight: 550,
-          autoPan: true,
-          closeButton: false,
-          autoPanPadding: [5, 5]
-        })
-      })
+export function createFeatureLayerADelt(map) {
+  let ADelt = L.featureGroup()
+
+  fetch(import.meta.env.VITE_API_URL + 'geojson/ADelt51.geojson')
+    .then(response => response.json())
+    .then(data => {
+      L.geoJSON(data, {
+        onEachFeature: function (feature, layer) {
+          layer.bindPopup('ADelt 51 : "' + feature.properties.Texte + '"<br>', {
+            maxWidth: 350,
+            maxHeight: 550,
+            autoPan: true,
+            closeButton: false,
+            autoPanPadding: [5, 5]
+          })
+        },
+        pointToLayer: function (feature, latlng) {
+          return L.marker(latlng, {
+            icon: L.divIcon({
+              html: feature.properties.Nom_GR,
+              className: 'ADelt-dot',
+              iconSize: 'null'
+            }),
+          })
+        },
+        pane: 'markerPane',
+        interactive: true,
+      }).addTo(ADelt)
     })
 
-  ADelt.on('layeradd', function (e) {
-    let marker = e.layer,
-      feature = marker.feature
-    marker.setIcon(
-      L.divIcon({
-        html: feature.properties.Nom_GR,
-        className: 'ADelt-dot',
-        iconSize: 'null'
-      })
-    )
+  ADelt.on('add', function () {
+    map.on('zoomend', show_hide_labels)
+    show_hide_labels()
   })
 
-  let show_label_zoom = 13 // zoom level threshold for showing/hiding labels
   function show_hide_labels() {
     let cur_zoom = map.getZoom()
-    if (cur_zoom <= show_label_zoom) {
-      map.removeLayer(ADelt)
-    } else if (cur_zoom > show_label_zoom) {
-      map.addLayer(ADelt)
+    if (cur_zoom <= 13) {
+      ADelt.eachLayer(function (layer) {
+        layer.getElement().style.visibility = 'hidden'
+      })
+    } else if (cur_zoom > 13) {
+      ADelt.eachLayer(function (layer) {
+        layer.getElement().style.visibility = 'visible'
+      })
     }
   }
 
-  map.on('zoomend', show_hide_labels)
-  show_hide_labels()
-
   return ADelt
 }
-*/
+
 /*export function createFeatureLayerSites() {
   return L.mapbox
     .featureLayer()

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -132,12 +132,11 @@ export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
           markerClusterGroupCeram.addLayer(layer)
         }
       })
-
-      featureLayerCeram.on('ready', function () {
-        search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram)
-        designMarkersCeram(featureLayerCeram)
-      })
     })
+
+  search.setupSearchCeramByText(markerClusterGroupCeram, map)
+  designMarkersCeram(featureLayerCeram)
+
   return featureLayerCeram
 }
 

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -112,25 +112,26 @@ export function setCeramLayer(ceramLayer) {
     })
 }
 */
-/*export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
-  let featureLayerCeram = L.mapbox
-    .featureLayer()
-    .loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
-    .on('ready', function (e) {
-      e.target.eachLayer(function (layer) {
-        setCeramLayer(layer)
+export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
+  fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
+    .then(response => response.json())
+    .then(data => {
+      let featureLayerCeram = L.geoJSON(data, {
+        onEachFeature: function (feature, layer) {
+          setCeramLayer(layer);
+          markerClusterGroupCeram.addLayer(layer);
+        }
+      });
 
-        markerClusterGroupCeram.addLayer(layer)
-      })
-    })
+      featureLayerCeram.on('ready', function () {
+        search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram);
+        designMarkersCeram(featureLayerCeram);
+      });
 
-  search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram)
-
-  designMarkersCeram(featureLayerCeram)
-
-  return featureLayerCeram
+      return featureLayerCeram;
+    });
 }
-*/
+
 export function createMarkerClusterGroupCeram() {
   return new L.MarkerClusterGroup({
     spiderfyOnMaxZoom: true,

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -163,7 +163,7 @@ function designMarkersCeram(layer) {
       L.divIcon({
         html: identifier,
         className: 'marker ceram-marker',
-        iconSize: 'null'
+        iconSize: [40, 40]
       })
     )
   })
@@ -221,7 +221,7 @@ export function createFeatureLayerChronique(markersChronique) {
         },
         pointToLayer: function (feature, latlng) {
           return L.marker(latlng, {
-            icon: L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' })
+            icon: L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: [40, 40] })
           })
         }
       })
@@ -236,7 +236,7 @@ export function createMarkerClusterGroupChronique() {
       return new L.DivIcon({
         html: '<div class="efa-cluster"><span>' + childCount + '</span></div>',
         className: 'efa-cluster',
-        iconSize: new L.Point(40, 40)
+        iconSize: [40, 40]
       })
     },
     spiderfyOnMaxZoom: true,
@@ -278,7 +278,7 @@ export function createFeatureLayerEchantillonsGeol() {
             icon: L.divIcon({
               html: feature.properties.RecNum,
               className: 'marker echantillons-geol-marker',
-              iconSize: null
+              iconSize: [40, 40]
             })
           })
         }
@@ -295,6 +295,15 @@ export function createFeatureLayerADelt(map) {
     .then((response) => response.json())
     .then((data) => {
       L.geoJSON(data, {
+        pointToLayer: function (feature, latlng) {
+          return L.marker(latlng, {
+            icon: L.divIcon({
+              html: feature.properties.Nom_GR,
+              className: 'ADelt-dot',
+              iconSize: 0
+            })
+          })
+        },
         onEachFeature: function (feature, layer) {
           layer.bindPopup('ADelt 51 : "' + feature.properties.Texte + '"<br>', {
             maxWidth: 350,
@@ -304,15 +313,7 @@ export function createFeatureLayerADelt(map) {
             autoPanPadding: [5, 5]
           })
         },
-        pointToLayer: function (feature, latlng) {
-          return L.marker(latlng, {
-            icon: L.divIcon({
-              html: feature.properties.Nom_GR,
-              className: 'ADelt-dot',
-              iconSize: 'null'
-            })
-          })
-        },
+
         pane: 'markerPane',
         interactive: true
       }).addTo(ADelt)

--- a/vue-thacer/src/assets/js/thacer-map-create-layer.js
+++ b/vue-thacer/src/assets/js/thacer-map-create-layer.js
@@ -40,18 +40,18 @@ export function setCeramLayer(ceramLayer) {
   }
   ceramLayer.bindPopup(
     archimageURL +
-    'Inventaire : ' +
-    identifier +
-    '<br>Identification : ' +
-    ceramLayer.feature.properties.Identification +
-    Type +
-    '<br>Description : ' +
-    ceramLayer.feature.properties.Description +
-    '<br>Bilbiographie : ' +
-    ceramLayer.feature.properties.Biblio +
-    '<br><a href=' +
-    createCeramUrl(ceramLayer, identifier) +
-    '>Fiche complète</a>',
+      'Inventaire : ' +
+      identifier +
+      '<br>Identification : ' +
+      ceramLayer.feature.properties.Identification +
+      Type +
+      '<br>Description : ' +
+      ceramLayer.feature.properties.Description +
+      '<br>Bilbiographie : ' +
+      ceramLayer.feature.properties.Biblio +
+      '<br><a href=' +
+      createCeramUrl(ceramLayer, identifier) +
+      '>Fiche complète</a>',
     {
       maxWidth: 350,
       minWidth: 350,
@@ -65,14 +65,14 @@ export function setCeramLayer(ceramLayer) {
 
 export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) {
   // create a new leaflet GeoJSON layer
-  const layer = L.geoJSON();
+  const layer = L.geoJSON()
 
   // fetch the data from the API URL using the fetch method
   fetch(import.meta.env.VITE_API_URL + 'geojson/secteurs.geojson')
-    .then(response => response.json()) // parse the response as JSON
-    .then(data => {
+    .then((response) => response.json()) // parse the response as JSON
+    .then((data) => {
       // add the GeoJSON data to the leaflet layer
-      layer.addData(data);
+      layer.addData(data)
 
       // set up the popup and click events for each layer
       layer.eachLayer(function (e) {
@@ -111,33 +111,33 @@ export function createFeatureLayerSecteurs(ceram, markerClusterGroupCeram, map) 
         e.on('click', function () {
           search.searchCeramByClick(ceram, markerClusterGroupCeram, map, e)
         })
-      });
-    });
+      })
+    })
 
   // return the leaflet layer
-  return layer;
+  return layer
 }
 
 export function createFeatureLayerCeram(markerClusterGroupCeram, map) {
   // create a new leaflet GeoJSON layer
-  let featureLayerCeram = L.geoJSON();
+  let featureLayerCeram = L.geoJSON()
 
   fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
-    .then(response => response.json())
-    .then(data => {
+    .then((response) => response.json())
+    .then((data) => {
       featureLayerCeram = L.geoJSON(data, {
         onEachFeature: function (feature, layer) {
-          setCeramLayer(layer);
-          markerClusterGroupCeram.addLayer(layer);
+          setCeramLayer(layer)
+          markerClusterGroupCeram.addLayer(layer)
         }
-      });
+      })
 
       featureLayerCeram.on('ready', function () {
-        search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram);
-        designMarkersCeram(featureLayerCeram);
-      });
-    });
-  return featureLayerCeram;
+        search.setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram)
+        designMarkersCeram(featureLayerCeram)
+      })
+    })
+  return featureLayerCeram
 }
 
 export function createMarkerClusterGroupCeram() {
@@ -170,24 +170,24 @@ function designMarkersCeram(featureLayerCeram) {
 }
 
 export function createFeatureLayerVestiges() {
-  let vestiges = L.featureGroup();
+  let vestiges = L.featureGroup()
 
   // Load GeoJSON data from URL
   fetch(import.meta.env.VITE_API_URL + 'geojson/vestiges.geojson')
-    .then(res => res.json())
-    .then(data => {
+    .then((res) => res.json())
+    .then((data) => {
       // Create a Leaflet GeoJSON layer from the data
-      let layer = L.geoJSON(data);
+      let layer = L.geoJSON(data)
 
       // Add the layer to the feature group
-      vestiges.addLayer(layer);
-    });
+      vestiges.addLayer(layer)
+    })
 
   vestiges.getAttribution = function () {
-    return 'Plan des vestiges antique : MWK TK EfA';
-  };
+    return 'Plan des vestiges antique : MWK TK EfA'
+  }
 
-  return vestiges;
+  return vestiges
 }
 
 export function createImageOverlayKhalil(map) {
@@ -221,9 +221,9 @@ export function createFeatureLayerChronique(markersChronique) {
         },
         pointToLayer: function (feature, latlng) {
           return L.marker(latlng, {
-            icon: L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' }),
+            icon: L.divIcon({ html: 'EfA', className: 'marker EFA-marker', iconSize: 'null' })
           })
-        },
+        }
       })
     })
 }
@@ -268,10 +268,10 @@ export function createTileLayerOrthophotoAgora() {
 }
 
 export function createFeatureLayerEchantillonsGeol() {
-  let echantillons = L.featureGroup();
+  let echantillons = L.featureGroup()
   fetch(import.meta.env.VITE_API_URL + 'geojson/echantillonsgeol.geojson')
-    .then(response => response.json())
-    .then(data => {
+    .then((response) => response.json())
+    .then((data) => {
       let layer = L.geoJSON(data, {
         pointToLayer: function (feature, latlng) {
           return L.marker(latlng, {
@@ -280,20 +280,20 @@ export function createFeatureLayerEchantillonsGeol() {
               className: 'marker echantillons-geol-marker',
               iconSize: null
             })
-          });
+          })
         }
-      });
-      echantillons.addLayer(layer);
-    });
-  return echantillons;
+      })
+      echantillons.addLayer(layer)
+    })
+  return echantillons
 }
 
 export function createFeatureLayerADelt(map) {
   let ADelt = L.featureGroup()
 
   fetch(import.meta.env.VITE_API_URL + 'geojson/ADelt51.geojson')
-    .then(response => response.json())
-    .then(data => {
+    .then((response) => response.json())
+    .then((data) => {
       L.geoJSON(data, {
         onEachFeature: function (feature, layer) {
           layer.bindPopup('ADelt 51 : "' + feature.properties.Texte + '"<br>', {
@@ -310,11 +310,11 @@ export function createFeatureLayerADelt(map) {
               html: feature.properties.Nom_GR,
               className: 'ADelt-dot',
               iconSize: 'null'
-            }),
+            })
           })
         },
         pane: 'markerPane',
-        interactive: true,
+        interactive: true
       }).addTo(ADelt)
     })
 
@@ -340,14 +340,17 @@ export function createFeatureLayerADelt(map) {
 }
 
 export function createFeatureLayerSites() {
-  let sites = L.featureGroup();
+  let sites = L.featureGroup()
 
   fetch(import.meta.env.VITE_API_URL + 'geojson/sites.geojson')
-    .then(response => response.json())
-    .then(data => {
+    .then((response) => response.json())
+    .then((data) => {
       L.geoJSON(data, {
         pointToLayer: function (feature, latlng) {
-          let iconUrl = feature.properties.type === 'Atelier' ? 'AmpTha.svg' : 'https://upload.wikimedia.org/wikipedia/commons/8/84/Maki-castle-15.svg';
+          let iconUrl =
+            feature.properties.type === 'Atelier'
+              ? 'AmpTha.svg'
+              : 'https://upload.wikimedia.org/wikipedia/commons/8/84/Maki-castle-15.svg'
           return L.marker(latlng, {
             icon: L.icon({
               iconUrl: iconUrl,
@@ -362,10 +365,10 @@ export function createFeatureLayerSites() {
             autoPan: true,
             closeButton: false,
             autoPanPadding: [5, 5]
-          });
+          })
         }
-      }).addTo(sites);
-    });
+      }).addTo(sites)
+    })
 
-  return sites;
+  return sites
 }

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -2,67 +2,77 @@ import { isObject, notifyProgrammaticError } from '@/assets/js/utils.js'
 import { setCeramLayer } from '@/assets/js/thacer-map-create-layer'
 import { mapToRealKeyName } from '@/assets/js/key-mapping'
 
-export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLayerCeram) {
-  let filterInput = document.getElementById('filter-input')
-  filterInput.addEventListener('keyup', function (e) {
-    if (e.keyCode == 13) {
-      let inputSearchString = e.target.value.trim().toLowerCase()
-      document.getElementById('nonloc').innerHTML = []
-
-      document.getElementById('loading-unlocalised').classList.remove('d-none')
-      fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
-        .then((r) => r.json())
-        .then((json) => {
-          Object.keys(json.features).forEach((k) => {
-            let obj = json.features[k]
-
-            // Adding current ceramObject only if unlocalised and passing input search string :
-            if (
-              obj.properties.x == 0 &&
-              doesCeramObjectPassesInputSearchString(obj.properties, inputSearchString)
-            ) {
-              let label
-              if (obj.properties.Pi != null) {
-                label = 'Π' + obj.properties.Pi
-              } else {
-                label = obj.properties.Inv_Fouille
-              }
-              document.getElementById('nonloc').innerHTML += [
-                '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
-                  obj.properties.ID +
-                  '&ANA=8888880&INV=88880">' +
-                  label +
-                  '</a>'
-              ]
-            }
-          })
-
-          document.getElementById('loading-unlocalised').classList.add('d-none')
-        })
-
-      markerClusterGroupCeram.clearLayers()
-      map.removeLayer(markerClusterGroupCeram)
-      featureLayerCeram.loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson') // je ne sais pourquoi j'avais mis ça là, déjà fait plus haut mais sinon map.addlayer ne marche pas
-
-      document.getElementById('loading-localised').classList.remove('d-none')
-      featureLayerCeram
-        .setFilter((e) => {
-          // Adding current ceramObject only if localised and passing input search string :
-          return (
-            e.properties.x != 0 &&
-            doesCeramObjectPassesInputSearchString(e?.properties, inputSearchString)
-          )
-        })
-        .on('ready', function (e) {
-          e.target.eachLayer(function (layer) {
-            setCeramLayer(layer)
-            markerClusterGroupCeram.addLayer(layer)
-          })
-          document.getElementById('loading-localised').classList.add('d-none')
-        })
-
-      map.addLayer(markerClusterGroupCeram)
+export function setupSearchCeramByText(markerClusterGroupCeram, map) {
+  /* global L */
+  const filterInput = document.getElementById('filter-input')
+  filterInput.addEventListener('keyup', (e) => {
+    if (e.keyCode !== 13) {
+      return
     }
+    if (!e.target.value) {
+      // Clear filter on submiting an empty field
+      document.getElementById('nonloc').innerHTML = []
+      markerClusterGroupCeram.clearLayers()
+      return
+    }
+    const inputSearchString = e.target.value.trim().toLowerCase()
+    document.getElementById('nonloc').innerHTML = []
+
+    document.getElementById('loading-unlocalised').classList.remove('d-none')
+    fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
+      .then((r) => r.json())
+      .then((json) => {
+        Object.keys(json.features).forEach((k) => {
+          let obj = json.features[k]
+
+          // Adding current ceramObject only if unlocalised and passing input search string :
+          if (
+            obj.properties.x == 0 &&
+            doesCeramObjectPassesInputSearchString(obj.properties, inputSearchString)
+          ) {
+            let label
+            if (obj.properties.Pi != null) {
+              label = 'Π' + obj.properties.Pi
+            } else {
+              label = obj.properties.Inv_Fouille
+            }
+            document.getElementById('nonloc').innerHTML += [
+              '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
+                obj.properties.ID +
+                '&ANA=8888880&INV=88880">' +
+                label +
+                '</a>'
+            ]
+          }
+        })
+
+        document.getElementById('loading-unlocalised').classList.add('d-none')
+      })
+
+    markerClusterGroupCeram.clearLayers()
+    map.removeLayer(markerClusterGroupCeram)
+    const ceramGeojsonUrl = import.meta.env.VITE_API_URL + 'geojson/ceram.geojson'
+    document.getElementById('loading-localised').classList.remove('d-none')
+    fetch(ceramGeojsonUrl)
+      .then((response) => response.json())
+      .then((data) => {
+        const geojsonLayer = L.geoJSON(data, {
+          filter: (e) => {
+            return (
+              e.properties.x != 0 &&
+              doesCeramObjectPassesInputSearchString(e?.properties, inputSearchString)
+            )
+          },
+          onEachFeature: (feature, layer) => {
+            setCeramLayer(layer)
+          }
+        })
+
+        markerClusterGroupCeram.clearLayers()
+        markerClusterGroupCeram.addLayer(geojsonLayer)
+        map.addLayer(markerClusterGroupCeram)
+        document.getElementById('loading-localised').classList.add('d-none')
+      })
   })
 }
 

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -50,7 +50,7 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map) {
       })
 
     markerClusterGroupCeram.clearLayers()
-    map.removeLayer(markerClusterGroupCeram)
+
     const ceramGeojsonUrl = import.meta.env.VITE_API_URL + 'geojson/ceram.geojson'
     document.getElementById('loading-localised').classList.remove('d-none')
     fetch(ceramGeojsonUrl)

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -29,10 +29,10 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
               }
               document.getElementById('nonloc').innerHTML += [
                 '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
-                obj.properties.ID +
-                '&ANA=8888880&INV=88880">' +
-                label +
-                '</a>'
+                  obj.properties.ID +
+                  '&ANA=8888880&INV=88880">' +
+                  label +
+                  '</a>'
               ]
             }
           })
@@ -147,8 +147,8 @@ export function searchCeramByClick(featureLayerCeram, markerClusterGroupCeram, m
   let value = layer.feature.properties.secteur_ID
   featureLayerCeram.clearLayers()
   fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
-    .then(response => response.json())
-    .then(data => {
+    .then((response) => response.json())
+    .then((data) => {
       featureLayerCeram.addData(data)
       featureLayerCeram.eachLayer(function (layer) {
         if (layer.feature.properties['secteur_ID'] == value) {

--- a/vue-thacer/src/assets/js/thacer-map-setup-search.js
+++ b/vue-thacer/src/assets/js/thacer-map-setup-search.js
@@ -29,10 +29,10 @@ export function setupSearchCeramByText(markerClusterGroupCeram, map, featureLaye
               }
               document.getElementById('nonloc').innerHTML += [
                 '<a class="unlocalised-tag px-1 m-0 border border-white" href="ceram?ID=' +
-                  obj.properties.ID +
-                  '&ANA=8888880&INV=88880">' +
-                  label +
-                  '</a>'
+                obj.properties.ID +
+                '&ANA=8888880&INV=88880">' +
+                label +
+                '</a>'
               ]
             }
           })
@@ -145,16 +145,16 @@ export function searchCeramByClick(featureLayerCeram, markerClusterGroupCeram, m
   map.removeLayer(markerClusterGroupCeram)
   markerClusterGroupCeram.clearLayers()
   let value = layer.feature.properties.secteur_ID
-  featureLayerCeram.loadURL(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
-  featureLayerCeram
-    .setFilter(function (feature) {
-      // Searching / Filtering for "click search" takes place here :
-      return feature.properties['secteur_ID'] == value
-    })
-    .on('ready', function (e) {
-      e.target.eachLayer(function (layer) {
-        setCeramLayer(layer)
-        markerClusterGroupCeram.addLayer(layer)
+  featureLayerCeram.clearLayers()
+  fetch(import.meta.env.VITE_API_URL + 'geojson/ceram.geojson')
+    .then(response => response.json())
+    .then(data => {
+      featureLayerCeram.addData(data)
+      featureLayerCeram.eachLayer(function (layer) {
+        if (layer.feature.properties['secteur_ID'] == value) {
+          setCeramLayer(layer)
+          markerClusterGroupCeram.addLayer(layer)
+        }
       })
     })
 

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -86,7 +86,7 @@ function createOverlays(map) {
   //createLayer.createFeatureLayerChronique(markerClusterGroupChronique)
 
   // The rest - hid-able/show-able in the control
-  //let vestiges = createLayer.createFeatureLayerVestiges()
+  let vestiges = createLayer.createFeatureLayerVestiges()
   /* let secteur = createLayer.createFeatureLayerSecteurs(
      featureLayerCeram,
      markerClusterGroupCeram,
@@ -100,7 +100,7 @@ function createOverlays(map) {
 
   // Finally, return the list of overlays which will be hid-able/show-able in the control
   return {
-    //'Vestiges antiques': vestiges.addTo(map), // Display on by default,
+    'Vestiges antiques': vestiges.addTo(map), // Display on by default,
     //'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
     'Plan Khalil 1954': khalil,
     //'Chronique des fouilles': markerClusterGroupChronique,

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -2,9 +2,6 @@ import * as createLayer from '@/assets/js/thacer-map-create-layer'
 
 export function thacerMap() {
   /* global L */
-  L.mapbox.accessToken =
-    'pk.eyJ1IjoianNncm9zIiwiYSI6ImNqOHQ0azNjcDBoYTEycXF1dzB0MzN4cDEifQ.DdPsBcV1XpWefQUPmBg9QA'
-
   const tileLayers = createTileLayers()
 
   const defaultTileLayer = tileLayers['Carte claire']
@@ -77,38 +74,39 @@ and return those which will be hid-able/show-able in the control*/
 function createOverlays(map) {
   // Ceram - always displayed
   let markerClusterGroupCeram = createLayer.createMarkerClusterGroupCeram()
-  let featureLayerCeram = createLayer.createFeatureLayerCeram(markerClusterGroupCeram, map)
+  //let featureLayerCeram = createLayer.createFeatureLayerCeram(markerClusterGroupCeram, map)
   markerClusterGroupCeram.addTo(map)
 
   // Adelt and Tours - always displayed (except on some zoom level for ADelt)
-  createLayer.createFeatureLayerADelt(map).addTo(map)
-  createLayer.createFeatureLayerSites().addTo(map)
+  //createLayer.createFeatureLayerADelt(map).addTo(map)
+  //createLayer.createFeatureLayerSites().addTo(map)
 
   // Chronique - hid-able/show-able in the control
-  let markerClusterGroupChronique = createLayer.createMarkerClusterGroupChronique()
-  createLayer.createFeatureLayerChronique(markerClusterGroupChronique)
+  //let markerClusterGroupChronique = createLayer.createMarkerClusterGroupChronique()
+  //createLayer.createFeatureLayerChronique(markerClusterGroupChronique)
 
   // The rest - hid-able/show-able in the control
-  let vestiges = createLayer.createFeatureLayerVestiges()
-  let secteur = createLayer.createFeatureLayerSecteurs(
-    featureLayerCeram,
-    markerClusterGroupCeram,
-    map
-  )
+  //let vestiges = createLayer.createFeatureLayerVestiges()
+  /* let secteur = createLayer.createFeatureLayerSecteurs(
+     featureLayerCeram,
+     markerClusterGroupCeram,
+     map
+   )
+   */
   let khalil = createLayer.createImageOverlayKhalil(map)
   let sigThasos = createLayer.createTileLayerSigThasos()
   let orthophotoAgora = createLayer.createTileLayerOrthophotoAgora()
-  let echantillonsGeol = createLayer.createFeatureLayerEchantillonsGeol()
+  //let echantillonsGeol = createLayer.createFeatureLayerEchantillonsGeol()
 
   // Finally, return the list of overlays which will be hid-able/show-able in the control
   return {
-    'Vestiges antiques': vestiges.addTo(map), // Display on by default,
-    'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
+    //'Vestiges antiques': vestiges.addTo(map), // Display on by default,
+    //'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
     'Plan Khalil 1954': khalil,
-    'Chronique des fouilles': markerClusterGroupChronique,
+    //'Chronique des fouilles': markerClusterGroupChronique,
     'Plan SIG agora': sigThasos,
     'Orthophoto agora EfA': orthophotoAgora,
 
-    'Echantillons géologiques': echantillonsGeol
+    //'Echantillons géologiques': echantillonsGeol
   }
 }

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -82,8 +82,8 @@ function createOverlays(map) {
   //createLayer.createFeatureLayerSites().addTo(map)
 
   // Chronique - hid-able/show-able in the control
-  //let markerClusterGroupChronique = createLayer.createMarkerClusterGroupChronique()
-  //createLayer.createFeatureLayerChronique(markerClusterGroupChronique)
+  let markerClusterGroupChronique = createLayer.createMarkerClusterGroupChronique()
+  createLayer.createFeatureLayerChronique(markerClusterGroupChronique)
 
   // The rest - hid-able/show-able in the control
   let vestiges = createLayer.createFeatureLayerVestiges()
@@ -103,7 +103,7 @@ function createOverlays(map) {
     'Vestiges antiques': vestiges.addTo(map), // Display on by default,
     //'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
     'Plan Khalil 1954': khalil,
-    //'Chronique des fouilles': markerClusterGroupChronique,
+    'Chronique des fouilles': markerClusterGroupChronique,
     'Plan SIG agora': sigThasos,
     'Orthophoto agora EfA': orthophotoAgora,
 

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -52,14 +52,11 @@ function createTileLayers() {
     }
   )
 
-  let light = L.tileLayer(
-    'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-    {
-      maxZoom: 20,
-      attribution:
-        'Tiles &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-    }
-  )
+  let light = L.tileLayer('https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+    maxZoom: 20,
+    attribution:
+      'Tiles &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+  })
 
   return {
     'Carte avec dénivellés': topo,

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -78,7 +78,7 @@ function createOverlays(map) {
   markerClusterGroupCeram.addTo(map)
 
   // Adelt and Tours - always displayed (except on some zoom level for ADelt)
-  //createLayer.createFeatureLayerADelt(map).addTo(map)
+  createLayer.createFeatureLayerADelt(map).addTo(map)
   //createLayer.createFeatureLayerSites().addTo(map)
 
   // Chronique - hid-able/show-able in the control

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -74,7 +74,7 @@ and return those which will be hid-able/show-able in the control*/
 function createOverlays(map) {
   // Ceram - always displayed
   let markerClusterGroupCeram = createLayer.createMarkerClusterGroupCeram()
-  //let featureLayerCeram = createLayer.createFeatureLayerCeram(markerClusterGroupCeram, map)
+  let featureLayerCeram = createLayer.createFeatureLayerCeram(markerClusterGroupCeram, map)
   markerClusterGroupCeram.addTo(map)
 
   // Adelt and Tours - always displayed (except on some zoom level for ADelt)

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -96,7 +96,7 @@ function createOverlays(map) {
   let khalil = createLayer.createImageOverlayKhalil(map)
   let sigThasos = createLayer.createTileLayerSigThasos()
   let orthophotoAgora = createLayer.createTileLayerOrthophotoAgora()
-  //let echantillonsGeol = createLayer.createFeatureLayerEchantillonsGeol()
+  let echantillonsGeol = createLayer.createFeatureLayerEchantillonsGeol()
 
   // Finally, return the list of overlays which will be hid-able/show-able in the control
   return {
@@ -106,7 +106,6 @@ function createOverlays(map) {
     'Chronique des fouilles': markerClusterGroupChronique,
     'Plan SIG agora': sigThasos,
     'Orthophoto agora EfA': orthophotoAgora,
-
-    //'Echantillons géologiques': echantillonsGeol
+    'Echantillons géologiques': echantillonsGeol
   }
 }

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -79,7 +79,7 @@ function createOverlays(map) {
 
   // Adelt and Tours - always displayed (except on some zoom level for ADelt)
   createLayer.createFeatureLayerADelt(map).addTo(map)
-  //createLayer.createFeatureLayerSites().addTo(map)
+  createLayer.createFeatureLayerSites().addTo(map)
 
   // Chronique - hid-able/show-able in the control
   let markerClusterGroupChronique = createLayer.createMarkerClusterGroupChronique()

--- a/vue-thacer/src/assets/js/thacer-map.js
+++ b/vue-thacer/src/assets/js/thacer-map.js
@@ -87,12 +87,12 @@ function createOverlays(map) {
 
   // The rest - hid-able/show-able in the control
   let vestiges = createLayer.createFeatureLayerVestiges()
-  /* let secteur = createLayer.createFeatureLayerSecteurs(
-     featureLayerCeram,
-     markerClusterGroupCeram,
-     map
-   )
-   */
+  let secteur = createLayer.createFeatureLayerSecteurs(
+    featureLayerCeram,
+    markerClusterGroupCeram,
+    map
+  )
+
   let khalil = createLayer.createImageOverlayKhalil(map)
   let sigThasos = createLayer.createTileLayerSigThasos()
   let orthophotoAgora = createLayer.createTileLayerOrthophotoAgora()
@@ -101,7 +101,7 @@ function createOverlays(map) {
   // Finally, return the list of overlays which will be hid-able/show-able in the control
   return {
     'Vestiges antiques': vestiges.addTo(map), // Display on by default,
-    //'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
+    'Secteurs de fouille et GTh': secteur.addTo(map), // Display on by default,
     'Plan Khalil 1954': khalil,
     'Chronique des fouilles': markerClusterGroupChronique,
     'Plan SIG agora': sigThasos,

--- a/vue-thacer/src/components/TheMap.vue
+++ b/vue-thacer/src/components/TheMap.vue
@@ -8,6 +8,10 @@
 import TheMapSearch from '@/components/TheMapSearch.vue'
 import TheMapInsertUnlocalised from '@/components/TheMapInsertUnlocalised.vue'
 import TheMapMainDisplay from '@/components/TheMapMainDisplay.vue'
+import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
+import 'leaflet.markercluster/dist/leaflet.markercluster.js'
 
 export default {
   name: 'TheMap',

--- a/vue-thacer/src/components/TheMapInsertUnlocalised.vue
+++ b/vue-thacer/src/components/TheMapInsertUnlocalised.vue
@@ -15,8 +15,6 @@ export default {
 }
 </script>
 
-<style scoped></style>
-
 <style>
 a.unlocalised-tag {
   border-radius: 10%;
@@ -25,5 +23,8 @@ a.unlocalised-tag {
   color: white;
   background: #f54b36;
   font-size: 10px;
+}
+.leaflet-container a {
+  color: white;
 }
 </style>

--- a/vue-thacer/src/components/TheMapMainDisplay.vue
+++ b/vue-thacer/src/components/TheMapMainDisplay.vue
@@ -39,9 +39,9 @@ g path {
   width: 98%;
 }
 
-/* modify .leaflet* classe for not overlapping map footer */
-.leaflet-control-zoom {
-  bottom: 30px;
+.leaflet-container {
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  background-clip: padding-box;
 }
 
 /* smaller font for map attribution due to lenghty credits*/

--- a/vue-thacer/src/components/TheMapMainDisplay.vue
+++ b/vue-thacer/src/components/TheMapMainDisplay.vue
@@ -84,8 +84,8 @@ g path {
 }
 
 .marker {
-  top: -20px !important;
-  left: -20px !important;
+  top: -20px;
+  left: -20px;
   border-radius: 100%;
   border-style: solid;
   width: 40px;

--- a/vue-thacer/src/components/TheMapMainDisplay.vue
+++ b/vue-thacer/src/components/TheMapMainDisplay.vue
@@ -60,7 +60,7 @@ g path {
 .marker-cluster-medium div,
 .marker-cluster-small div,
 .marker-cluster-large div {
-  background-color: rgba(245, 75, 54, 0.7);
+  background-color: rgba(245, 75, 54, 0.7) !important;
 }
 
 .efa-cluster,
@@ -84,8 +84,8 @@ g path {
 }
 
 .marker {
-  top: -20px;
-  left: -20px;
+  top: -20px !important;
+  left: -20px !important;
   border-radius: 100%;
   border-style: solid;
   width: 40px;


### PR DESCRIPTION
#103 refactor map layers to use leaflet instead of mapbox

**Description** :    
@AlZorba , @francoiscrouzet , check this branch. Mapbox is gone and all layers work. There are some changes in the appearance but these can be adjusted (discuss first?). As a positive side effect, some of the errors that populated the console previously are gone.

Problems:
If you click on a sector the function searchCeramByClick will throw an error 'featureLayerCeram is undefined'. I can investigate further, but I wonder whether it would be better to address this as part of https://github.com/archaiodata/thacer/issues/84.

I am not sure why Prettier insists on changing spaces in the reworked index.html.
