### PR TITLE
Allow either http or https

### DIFF
--- a/vue-thacer/.env
+++ b/vue-thacer/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://thacer.archaiodata.com/API/
+VITE_API_URL=//thacer.archaiodata.com/API/

--- a/vue-thacer/vite.config.js
+++ b/vue-thacer/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(({ command }) => {
     config.server = {
       proxy: {
         '/proxys_replacement_key_for_api_path_in_dev': {
-          target: 'http://thacer.archaiodata.com/API/',
+          target: 'https://thacer.archaiodata.com/API/',
           changeOrigin: true,
           secure: false,
           rewrite: (path) => path.replace(/^\/proxys_replacement_key_for_api_path_in_dev/, '')


### PR DESCRIPTION
**Issue** :  `https://github.com/archaiodata/thacer/issues/121`

**Description** :    
This PR fix a bug in prod when using https://thacer.archaiodata.com/
doesn't load data sources and error message :
Mixed Content: The page at '' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint ''. This request has been blocked; the content must be served over HTTPS.
